### PR TITLE
Replace deprecated/removed raw::TraitObject

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(raw)]
 #![allow(non_snake_case)]
 
 mod app;


### PR DESCRIPTION
I tried building the binary on a newer version of rust. Getting the following error:

```
error[E0432]: unresolved import `std::raw`
 --> src/app.rs:9:28
  |
9 | use std::{mem, ops::Deref, raw};
  |                            ^^^ no `raw` in the root
```

The commit from @dj95's fork builds successfully.