### PR TITLE
Replace onchange with before and after

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,24 @@ dn.run({
         -- example
         github = (vim.g.plug_home .. "/vim-colors-github/autoload/lightline/colorscheme/github.vim")
     },
-    onchange = function(mode)
-        -- optional, you can configure your own things to react to changes.
-        -- this is called at startup and every time dark mode is switched,
-        -- either via the OS, or because you manually set/toggled the mode.
-        -- mode is either "light" or "dark"
+    -- optionally, you can configure what to do before/after changes.
+    -- this is called at startup and every time dark mode is switched,
+    -- either via the OS, or because you manually set/toggled the mode.
+    -- mode is either "light" or "dark"
+    before = function(mode)
+        -- your logic here
+        if mode == "dark" then
+            -- do something
+        else
+            -- do other thing
+        end
+    end,
+    after = function(mode)
+        if mode == "dark" then
+            -- do something
+        else
+            -- do other thing
+        end
     end,
 })
 

--- a/lua/dark_notify.lua
+++ b/lua/dark_notify.lua
@@ -53,6 +53,10 @@ local function apply_mode(mode)
   local bg = sel.background or mode
   local lltheme = sel.lightline or nil
 
+  if config.before ~= nil then
+    config.before(mode)
+  end
+
   vim.api.nvim_command('set background=' .. bg)
   if colorscheme ~= nil then
     vim.api.nvim_command('colorscheme ' .. colorscheme)
@@ -79,9 +83,10 @@ local function apply_mode(mode)
     end
   end
 
-  if config.onchange ~= nil then
-    config.onchange(mode)
+  if config.after ~= nil then
+    config.after(mode)
   end
+
 
   state.current_mode = mode
 end
@@ -181,7 +186,8 @@ function M.configure(config)
   end
   local lightline_loaders = config.lightline_loaders or {}
   local schemes = config.schemes or {}
-  local onchange = config.onchange
+  local before = config.before
+  local after = config.after
 
   for _, mode in pairs({ "light", "dark" }) do
     if type(schemes[mode]) == "string" then
@@ -192,7 +198,8 @@ function M.configure(config)
   edit_config(function (conf)
     conf.lightline_loaders = lightline_loaders
     conf.schemes = schemes
-    conf.onchange = onchange
+    conf.before = before
+    conf.after = after
   end)
 end
 


### PR DESCRIPTION
I'm using [Catppuccin](https://github.com/catppuccin/nvim) colorscheme and it comes with multiple flavour. In my case, I needed to set the flavour first and then apply the colorscheme after. The `onchange` is a bit confusing since it is called _**after**_ we apply the theme. I suggest we split it up to `before` and `after` in order to be more intuitive and could be useful for some people. 

This could break existing config though since `onchage` is no longer available