### PR TITLE
README.md: Mention tmux-dark-notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,5 @@ $ dark-notify -c 'python3 my-script.py'
 
 `dark-notify -h` for more options.
 
+## Related tools
+* [erikw/tmux-dark-notify](https://github.com/erikw/tmux-dark-notify) - this tmux plugin uses `dark-notify` to make tmux's theme follow macOS dark/light mode.


### PR DESCRIPTION
Hey,

thanks for this great tool `dark-notify`. I very much enjoy my NeomNim instances automatically switching color mode as the system switches!

Today I switched to iTerm 3.5beta as it has built-in support for changing the terminal theme's to a light/dark configuration. As I did this I realized that the only thing that prevented my from fully remove my very complex [home-cooked script soup ](https://github.com/erikw/dotfiles/commit/58cf14806c16c1d7c99d741cf09e5aa24333066c) (the deleted files) for automatically setting light/dark mode based on the system's mode, was `tmux`.

I saw that dark-notify has `-c` switch, and a plugin was born thereof!
➡️ [erikw/tmux-dark-notify](https://github.com/erikw/tmux-dark-notify)

I though it could be useful to share a link in a new section `Related tools`, as many Neovim users' also are tmux users, and could benefit from this new plugin :). 