### PR TITLE
fix: replace vim.tbl_flatten with vim.iter

### DIFF
--- a/lua/dark_notify.lua
+++ b/lua/dark_notify.lua
@@ -12,7 +12,7 @@ function nvim_create_augroups(definitions)
       -- if type(def) == 'table' and type(def[#def]) == 'function' then
       -- 	def[#def] = lua_callback(def[#def])
       -- end
-      local command = table.concat(vim.tbl_flatten{'autocmd', def}, ' ')
+      local command = table.concat(vim.iter({'autocmd', def}):flatten():totable() , ' ')
       vim.api.nvim_command(command)
     end
     vim.api.nvim_command('augroup END')


### PR DESCRIPTION
vim.tbl_flatten will be deprecated in nvim 0.13; this PR simply updates to the recommended function.

See the following deprecation notice:

```
- WARNING vim.tbl_flatten is deprecated. Feature will be removed in Nvim 0.13
  - ADVICE:
    - use vim.iter(…):flatten():totable() instead.
    - stack traceback:
        /HOME/.local/share/nvim/lazy/dark-notify/lua/dark_notify.lua:15
        /HOME/.local/share/nvim/lazy/dark-notify/lua/dark_notify.lua:160
        /HOME/.local/share/nvim/lazy/dark-notify/lua/dark_notify.lua:209
        /HOME/.config/nvim/lua/plugins/ui/dark-notify.lua:5
        /HOME/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:380
        [C]:-1
        /HOME/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:135
        /HOME/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:395
        /HOME/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:362
        /HOME/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:197
        /HOME/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:127
        /HOME/.local/share/nvim/lazy/lazy.nvim/lua/lazy/init.lua:112
        /HOME/rc/nvim/init.lua:251
        /HOME/rc/nvim/init.lua:295
```